### PR TITLE
use time v1.5

### DIFF
--- a/haspot.cabal
+++ b/haspot.cabal
@@ -25,7 +25,7 @@ executable haspot
                        filepath,
                        old-locale,
                        pandoc >= 1.14,
-                       time,
+                       time >= 1.5,
                        yaml
   main-is:             haspot.hs
   default-language:    Haskell2010


### PR DESCRIPTION
The function `parseTimeM` is used and exists time >= v1.5.

I meet the error message after executed `cabal install` command.

```
haspot.hs:13:36:
    Module ‘Data.Time.Format’ does not export ‘parseTimeM’


haspot.hs:16:36:
    Module ‘Data.Time.Format’ does not export ‘defaultTimeLocale’
Updating documentation index
/Users/yen3/Downloads/haspot/.cabal-sandbox/share/doc/x86_64-osx-ghc-7.8.3/index.html
cabal: Error: some packages failed to install:
haspot-0.1.0.0 failed during the building phase. The exception was:
ExitFailure 1
```

The default install version of time package is 1.4.0.2. I reinstall time-1.5.0.1 package to solve the problem.
